### PR TITLE
Create a Dash feed XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dash-docset-tensorflow
 Build [dash](https://kapeli.com/dash)/[zeal](https://github.com/zealdocs/zeal) docset for [TensorFlow](https://www.tensorflow.org/).
 
-You can download the latest release [here](https://github.com/ppwwyyxx/dash-docset-tensorflow/releases). Or add this feed `dash-feed://https%3A//raw.githubusercontent.com/kho/dash-docset-tensorflow/master/TensorFlow.xml` directly in Dash/Zeal.
+You can download the latest release [here](https://github.com/ppwwyyxx/dash-docset-tensorflow/releases). Or add this feed `dash-feed://https%3A//raw.githubusercontent.com/ppwwyyxx/dash-docset-tensorflow/master/TensorFlow.xml` directly in Dash/Zeal.
 
 ## Steps to generate the docset
 + Install [dashing](https://github.com/technosophos/dashing): `go get -u github.com/technosophos/dashing`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dash-docset-tensorflow
 Build [dash](https://kapeli.com/dash)/[zeal](https://github.com/zealdocs/zeal) docset for [TensorFlow](https://www.tensorflow.org/).
 
-You can download the latest release [here](https://github.com/ppwwyyxx/dash-docset-tensorflow/releases).
+You can download the latest release [here](https://github.com/ppwwyyxx/dash-docset-tensorflow/releases). Or add this feed `dash-feed://https%3A//raw.githubusercontent.com/kho/dash-docset-tensorflow/master/TensorFlow.xml` directly in Dash/Zeal.
 
 ## Steps to generate the docset
 + Install [dashing](https://github.com/technosophos/dashing): `go get -u github.com/technosophos/dashing`

--- a/TensorFlow.xml
+++ b/TensorFlow.xml
@@ -1,0 +1,4 @@
+<entry>
+  <version>1.3</version>
+  <url>https://github.com/ppwwyyxx/dash-docset-tensorflow/releases/download/v1.3/TensorFlow-1.3.tgz</url>
+</entry>


### PR DESCRIPTION
This makes installing/updating the docset much easier. With each new release, the feed can be updated. Zeal users will be able to update just be re-adding the same feed URL. I don't have Dash, but looking at its doc [https://kapeli.com/docsets#dashdocsetfeed], I suppose it can pick up the update automatically.